### PR TITLE
Add skipFragment option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## Head
+
+- **[Breaking change]**: Add `skipFragment` option, defaulting to `false`.
+  So links to fragments (e.g. `href="#foo"`) are no longer hijacked by default.
+
+## 0.3.2
+
+- Start this log.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Head
 
-- **[Breaking change]**: Add `skipFragment` option, defaulting to `false`.
+- **[Breaking change]**: Add `skipFragment` option, defaulting to `true`.
   So links to fragments (e.g. `href="#foo"`) are no longer hijacked by default.
 
 ## 0.3.2

--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ Type: `boolean`. Default: `false`.
 By default, links pointing to other origins (protocol + domain) are not hijacked.
 If this option is `true`, these links will still be hijacked.
 
+##### skipFragment
+
+Type: `boolean`. Default: `false`.
+
+By default, links starting with fragments (e.g. `href="#foo"`) are not hijacked.
+If this option is `true`, these links will still be hijacked.
+
 ##### skipFilter
 
 Type: `Function`.

--- a/README.md
+++ b/README.md
@@ -64,52 +64,52 @@ Links will be hijacked within this element.
 
 ##### skipModifierKeys
 
-Type: `boolean`. Default: `false`.
+Type: `boolean`. Default: `true`.
 
 By default, clicks paired with modifiers keys (`ctrlKey`, `altKey`, `metaKey`, `shiftKey`) are not hijacked.
-If this option is `true`, these clicks will still be hijacked.
+If this option is `false`, these clicks will still be hijacked.
 
 ##### skipDownload
 
-Type: `boolean`. Default: `false`.
+Type: `boolean`. Default: `true`.
 
 By default, links with the `download` attribute are not hijacked.
-If this option is `true`, these links will still be hijacked.
+If this option is `false`, these links will still be hijacked.
 
 ##### skipTargetBlank
 
-Type: `boolean`. Default: `false`.
+Type: `boolean`. Default: `true`.
 
 By default, links with the attribute `target="_blank"` are not hijacked.
-If this option is `true`, these links will still be hijacked.
+If this option is `false`, these links will still be hijacked.
 
 ##### skipExternal
 
-Type: `boolean`. Default: `false`.
+Type: `boolean`. Default: `true`.
 
 By default, links with the attribute `rel="external"` are not hijacked.
-If this option is `true`, these links will still be hijacked.
+If this option is `false`, these links will still be hijacked.
 
 ##### skipMailTo
 
-Type: `boolean`. Default: `false`.
+Type: `boolean`. Default: `true`.
 
 By default, links whose hrefs start with `mailto:` are not hijacked.
-If this option is `true`, these links will still be hijacked.
+If this option is `false`, these links will still be hijacked.
 
 ##### skipOtherOrigin
 
-Type: `boolean`. Default: `false`.
+Type: `boolean`. Default: `true`.
 
 By default, links pointing to other origins (protocol + domain) are not hijacked.
-If this option is `true`, these links will still be hijacked.
+If this option is `false`, these links will still be hijacked.
 
 ##### skipFragment
 
-Type: `boolean`. Default: `false`.
+Type: `boolean`. Default: `true`.
 
 By default, links starting with fragments (e.g. `href="#foo"`) are not hijacked.
-If this option is `true`, these links will still be hijacked.
+If this option is `false`, these links will still be hijacked.
 
 ##### skipFilter
 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function hijack(options, callback) {
   var skipExternal = setDefault(options.skipExternal, true);
   var skipMailTo = setDefault(options.skipMailTo, true);
   var skipOtherOrigin = setDefault(options.skipOtherOrigin, true);
+  var skipFragment = setDefault(options.skipFragment, true);
 
   function onClick(e) {
     if (e.defaultPrevented) return;
@@ -43,6 +44,7 @@ function hijack(options, callback) {
     if (!link) return;
 
     if (options.skipFilter && options.skipFilter(link)) return;
+    if (skipFragment && /^#/.test(link.getAttribute('href'))) return;
     if (skipDownload && link.hasAttribute('download')) return;
     if (skipExternal && link.getAttribute('rel') === 'external') return;
     if (skipTargetBlank && link.getAttribute('target') === '_blank') return;

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -192,6 +192,30 @@
     </div>
   </div>
 
+  <div id="fraggle" class="mt12 px24 py12 border border--gray-light round">
+    <div class="txt-s color-gray mb6">
+      anchor with fragment href
+    </div>
+    <div class="flex-parent flex-parent--space-between-main">
+      <div class="flex-child">
+        <a id="anchor-with-fragment" class="link" href="#fraggle">anchor-with-fragment</a>
+      </div>
+      <div id="anchor-with-fragment-count" class="flex-child txt-bold">0</div>
+    </div>
+  </div>
+
+  <div id="fraggle" class="mt12 px24 py12 border border--gray-light round">
+    <div class="txt-s color-gray mb6">
+      anchor with href URL containing (but not starting with) fragment
+    </div>
+    <div class="flex-parent flex-parent--space-between-main">
+      <div class="flex-child">
+        <a id="anchor-with-noninitial-fragment" class="link" href="/foo/#fraggle">anchor-with-noninitial-fragment</a>
+      </div>
+      <div id="anchor-with-noninitial-fragment-count" class="flex-child txt-bold">0</div>
+    </div>
+  </div>
+
   <script src="manual.js"></script>
 </body>
 </html>

--- a/test/manual/manual.js
+++ b/test/manual/manual.js
@@ -30,6 +30,7 @@ switchButton.addEventListener('click', function() {
         skipExternal: false,
         skipMailTo: false,
         skipOtherOrigin: false,
+        skipFragment: false,
         skipFilter: function(link) {
           return link.hasAttribute('data-no-hijack');
         }

--- a/test/test.js
+++ b/test/test.js
@@ -375,4 +375,48 @@ describe('hijack', () => {
     handler(mockEvent);
     expect(callbackCalled).toBe(false);
   });
+
+  test('skips fragments', () => {
+    let callbackCalled = false;
+    remove = linkHijacker.hijack({ root }, () => {
+      callbackCalled = true;
+    });
+    const handler = root.addEventListener.mock.calls[0][1];
+    link.setAttribute('href', '#foo');
+    handler(mockEvent);
+    expect(callbackCalled).toBe(false);
+  });
+
+  test('does not skip URLs ending with fragments', () => {
+    let callbackCalled = false;
+    remove = linkHijacker.hijack({ root }, () => {
+      callbackCalled = true;
+    });
+    const handler = root.addEventListener.mock.calls[0][1];
+    link.setAttribute('href', '/foo/bar#baz');
+    handler(mockEvent);
+    expect(callbackCalled).toBe(true);
+  });
+
+  test('does not skip URLs ending with slash + fragments', () => {
+    let callbackCalled = false;
+    remove = linkHijacker.hijack({ root }, () => {
+      callbackCalled = true;
+    });
+    const handler = root.addEventListener.mock.calls[0][1];
+    link.setAttribute('href', '/foo/bar/#baz');
+    handler(mockEvent);
+    expect(callbackCalled).toBe(true);
+  });
+
+  test('options.skipFragment', () => {
+    let callbackCalled = false;
+    remove = linkHijacker.hijack({ root, skipFragment: false }, () => {
+      callbackCalled = true;
+    });
+    const handler = root.addEventListener.mock.calls[0][1];
+    link.setAttribute('href', '#foo');
+    handler(mockEvent);
+    expect(callbackCalled).toBe(true);
+  });
 });


### PR DESCRIPTION
This is a breaking change, because fragments are no longer hijacked by default.

Relates to https://github.com/mapbox/batfish/issues/144

@jfurrow for review.